### PR TITLE
Corrected dtd uri

### DIFF
--- a/core/src/main/module.gwt.xml
+++ b/core/src/main/module.gwt.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.8.0//EN"
-  "http://gwtproject.org/doctype/2.8.0/gwt-module.dtd">
+  "http://www.gwtproject.org/doctype/2.8.0/gwt-module.dtd">
 <module>
   <inherits name="jsinterop.base.Base"/>
   <inherits name="elemental2.core.Core"/>


### PR DESCRIPTION
The GWT module dtd requires the `www` subdomain to resolve correctly. A (mostly ignorable) error is otherwise thrown in the IDE.

