### PR TITLE
Add behaviour to find and parse external css and scss files into the component

### DIFF
--- a/processors/src/main/java/com/axellience/vuegwt/processors/component/template/parser/StyleParser.java
+++ b/processors/src/main/java/com/axellience/vuegwt/processors/component/template/parser/StyleParser.java
@@ -1,0 +1,83 @@
+package com.axellience.vuegwt.processors.component.template.parser;
+
+import java.net.URI;
+import java.util.Optional;
+
+import javax.annotation.processing.Messager;
+
+import com.axellience.vuegwt.processors.component.template.parser.TemplateScopedCssParser.ScopedCssResult;
+import com.axellience.vuegwt.processors.component.template.parser.context.StyleParserContext;
+import com.axellience.vuegwt.processors.component.template.parser.result.StyleParserResult;
+import com.axellience.vuegwt.processors.component.template.parser.result.TemplateParserResult;
+
+import io.bit3.jsass.CompilationException;
+import io.bit3.jsass.Compiler;
+import io.bit3.jsass.Options;
+import io.bit3.jsass.Output;
+import io.bit3.jsass.context.StringContext;
+
+public class StyleParser {
+  private StyleParserContext context;
+  private Messager messager;
+  private StyleParserLogger logger;
+  private StyleParserResult result;
+  private URI htmlTemplateUri;
+
+  /**
+   * Parse a given HTML template and return the a result object containing the
+   * expressions and a transformed HTML.
+   *
+   * @param styleTemplate The SCSS or CSS template to process, as a String
+   * @param content
+   * @param context       Context of the Component we are currently processing
+   * @param messager      Used to report errors in template during Annotation
+   *                      Processing
+   * @return A {@link TemplateParserResult} containing the processed template and
+   *         expressions
+   */
+  public StyleParserResult parseStyleTemplate(String type, String content, StyleParserContext context,
+      Messager messager, URI htmlTemplateUri) {
+    this.context = context;
+    this.messager = messager;
+    this.logger = new StyleParserLogger(context, messager);
+    this.htmlTemplateUri = htmlTemplateUri;
+
+    result = new StyleParserResult();
+    result.setScopedCss(processScopedCss(type, content));
+
+    return result;
+  }
+
+  private String processScopedCss(String type, String styleScoped) {
+    String[] scopedCss = new String[1];
+
+    String css = styleScoped.trim();
+    if (!css.isEmpty()) {
+      if (type.equals("scss")) { // [file].scss
+        css = scssToCss(css);
+      }
+      TemplateScopedCssParser scopedCssParser = new TemplateScopedCssParser(messager);
+      Optional<ScopedCssResult> scopedCssResult = scopedCssParser.parse(context.getComponentTypeElement(), css);
+      if (scopedCssResult.isPresent()) {
+        context.getMandatoryAttributes().putAll(scopedCssResult.get().mandatoryAttributes);
+        scopedCss[0] = scopedCssResult.get().scopedCss;
+      }
+    }
+
+    return scopedCss[0];
+  }
+
+  private String scssToCss(String scss) {
+    Compiler compiler = new Compiler();
+    Options options = new Options();
+
+    try {
+      StringContext context = new StringContext(scss, this.htmlTemplateUri, null/* outputPath */, options);
+      Output output = compiler.compile(context);
+      return output.getCss();
+    } catch (CompilationException e) {
+      logger.error("SCSS compile failed: " + e.getErrorText());
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/processors/src/main/java/com/axellience/vuegwt/processors/component/template/parser/StyleParserLogger.java
+++ b/processors/src/main/java/com/axellience/vuegwt/processors/component/template/parser/StyleParserLogger.java
@@ -1,0 +1,77 @@
+package com.axellience.vuegwt.processors.component.template.parser;
+
+import javax.annotation.processing.Messager;
+import javax.tools.Diagnostic.Kind;
+
+import com.axellience.vuegwt.processors.component.template.parser.context.StyleParserContext;
+
+import net.htmlparser.jericho.Logger;
+
+public class StyleParserLogger implements Logger {
+
+  private final StyleParserContext context;
+  private final Messager messager;
+
+  StyleParserLogger(StyleParserContext context, Messager messager) {
+    this.context = context;
+    this.messager = messager;
+  }
+
+  void error(String message, String expression) {
+    error(message + " In expression: " + expression);
+  }
+
+  @Override
+  public void error(String message) {
+    // Filter errors about invalid first attribute character
+    // The @ sign is not recognized as valid when its valid in Vue GWT
+    // A cleaner way would be to fork Jericho to add the support for @
+    // But this filter should do for now.
+    if (message.contains("contains attribute name with invalid first character")) {
+      return;
+    }
+
+    printMessage(Kind.ERROR, message);
+  }
+
+  @Override
+  public void warn(String message) {
+    printMessage(Kind.WARNING, message);
+  }
+
+  @Override
+  public void info(String message) {
+    printMessage(Kind.NOTE, message);
+  }
+
+  @Override
+  public void debug(String message) {
+    printMessage(Kind.OTHER, message);
+  }
+
+  public void printMessage(Kind kind, String message) {
+    messager.printMessage(kind,
+        "In " + context.getTemplateName() + ": " + message,
+        context.getComponentTypeElement());
+  }
+
+  @Override
+  public boolean isErrorEnabled() {
+    return true;
+  }
+
+  @Override
+  public boolean isWarnEnabled() {
+    return true;
+  }
+
+  @Override
+  public boolean isInfoEnabled() {
+    return true;
+  }
+
+  @Override
+  public boolean isDebugEnabled() {
+    return true;
+  }
+}

--- a/processors/src/main/java/com/axellience/vuegwt/processors/component/template/parser/context/StyleParserContext.java
+++ b/processors/src/main/java/com/axellience/vuegwt/processors/component/template/parser/context/StyleParserContext.java
@@ -1,0 +1,45 @@
+package com.axellience.vuegwt.processors.component.template.parser.context;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.lang.model.element.TypeElement;
+
+import com.axellience.vuegwt.core.client.component.IsVueComponent;
+
+public class StyleParserContext {
+  private final TypeElement componentTypeElement;
+
+  /**
+   * In some cases mandatory attributes must be added to each element during template parsing, for example to support scoped styles
+   */
+  private final Map<String, String> mandatoryAttributes = new HashMap<>();
+
+  /**
+   * Build the context based on a given {@link IsVueComponent} Class.
+   *
+   * @param componentTypeElement
+   *          The {@link IsVueComponent} class we process in this context
+   */
+  public StyleParserContext(final TypeElement componentTypeElement) {
+    this.componentTypeElement = componentTypeElement;
+  }
+
+  /**
+   * Simple getter for the currently processed {@link IsVueComponent} Template name. Used for
+   * debugging.
+   *
+   * @return The currently process {@link IsVueComponent} Template name
+   */
+  public String getTemplateName() {
+    return componentTypeElement.getSimpleName().toString() + ".scss";
+  }
+
+  public TypeElement getComponentTypeElement() {
+    return componentTypeElement;
+  }
+
+  public Map<String, String> getMandatoryAttributes() {
+    return mandatoryAttributes;
+  }
+}

--- a/processors/src/main/java/com/axellience/vuegwt/processors/component/template/parser/result/StyleParserResult.java
+++ b/processors/src/main/java/com/axellience/vuegwt/processors/component/template/parser/result/StyleParserResult.java
@@ -1,0 +1,13 @@
+package com.axellience.vuegwt.processors.component.template.parser.result;
+
+public class StyleParserResult {
+  private String scopedCss;
+
+  public String getScopedCss() {
+    return scopedCss;
+  }
+
+  public void setScopedCss(final String scopedCss) {
+    this.scopedCss = scopedCss;
+  }
+}

--- a/processors/src/test/java/com/axellience/vuegwt/processors/component/template/parser/TemplateParserTest.java
+++ b/processors/src/test/java/com/axellience/vuegwt/processors/component/template/parser/TemplateParserTest.java
@@ -25,4 +25,19 @@ class TemplateParserTest {
         .containsElementsIn(JavaFileObjects.forResource(
             "templateparser/compileresult/MustacheExpressionComponentExposedType.java"));
   }
+
+  @Test
+  @DisplayName("should compile an external stylesheet")
+  void componentWithExternalStylesheet() {
+    Compilation compilation =
+        javac()
+            .withProcessors(new VueGwtProcessor())
+            .compile(
+                JavaFileObjects.forResource("templateparser/StyledComponent.java"));
+
+    assertThat(compilation)
+        .generatedSourceFile("templateparser.StyledComponentExposedType")
+        .containsElementsIn(JavaFileObjects.forResource(
+            "templateparser/compileresult/StyledComponentExposedType.java"));
+  }
 }

--- a/processors/src/test/resources/templateparser/StyledComponent.html
+++ b/processors/src/test/resources/templateparser/StyledComponent.html
@@ -1,0 +1,2 @@
+<div class="tested">
+</div>

--- a/processors/src/test/resources/templateparser/StyledComponent.java
+++ b/processors/src/test/resources/templateparser/StyledComponent.java
@@ -1,0 +1,8 @@
+package templateparser;
+
+import com.axellience.vuegwt.core.annotations.component.Component;
+import com.axellience.vuegwt.core.client.component.IsVueComponent;
+
+@Component
+public class StyledComponent implements IsVueComponent {
+}

--- a/processors/src/test/resources/templateparser/StyledComponent.scss
+++ b/processors/src/test/resources/templateparser/StyledComponent.scss
@@ -1,0 +1,3 @@
+.tested {
+  background:green;
+}

--- a/processors/src/test/resources/templateparser/compileresult/StyledComponentExposedType.java
+++ b/processors/src/test/resources/templateparser/compileresult/StyledComponentExposedType.java
@@ -1,0 +1,13 @@
+package templateparser;
+
+@Generated(
+    value = "com.axellience.vuegwt.processors.component.ComponentExposedTypeGenerator",
+    comments = "https://github.com/Axellience/vue-gwt"
+)
+public class StyledComponentExposedType extends StyledComponent {
+  
+  public static String getScopedCss() {
+    return ".tested[data-v-7b666a75]{background:green}";
+  }
+
+}


### PR DESCRIPTION
This change adds behaviour to look for and parse an optional css and scss file as part of the component template.

File structure such as the following is then possible, allowing full segregation of presenter logic, markup/view logic, and styling:

```
DummyComponent.java
DummyComponent.html
DummyComponent.scss
```

The embedded `<style scoped>` element continues to function as usual and expected.

Combinations of styles are possible; all styles found (embedded css/scss, external scss file, and an external css file) are concatenated into the final `scopedCss` string.

---

I've tried to replicate the existing approach to parsing the template as much as possible so as to make this change cohere to the rest of the codebase as much as possible. Let me know if I can improve on any aspect!