### PR TITLE
Explicitly check for long values in fields.

### DIFF
--- a/core/src/main/java/com/axellience/vuegwt/core/client/tools/VueGWTTools.java
+++ b/core/src/main/java/com/axellience/vuegwt/core/client/tools/VueGWTTools.java
@@ -145,6 +145,7 @@ public class VueGWTTools {
         Any val = asAny(map.get(key));
         if (isTripleEqual(val, null) ||
             isTripleEqual(val, asAny(1)) ||
+            isTripleEqual(val, asAny(1L)) ||
             isTripleEqual(val, asAny(true))) {
           map.delete(key);
         }
@@ -165,6 +166,7 @@ public class VueGWTTools {
         Any val = asAny(map.get(key));
         if (isTripleEqual(val, null) ||
             isTripleEqual(val, asAny(1)) ||
+            isTripleEqual(val, asAny(1L)) ||
             isTripleEqual(val, asAny(true))) {
           dataFields.add(key);
         }


### PR DESCRIPTION
This is necessary in J2CL since closure doesn't emulate longs in the
same way as GWT2, so a small enough long is still an object instead
of being handled as a plain JS Number.