### PR TITLE
Clean up the processor's dependencies slightly, and generate a shaded jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <jericho.version>3.4</jericho.version>
     <javaparser.version>3.0.1</javaparser.version>
     <auto-service.version>1.0-rc4</auto-service.version>
+    <auto-common.version>0.8</auto-common.version>
     <ph-css.version>6.1.1</ph-css.version>
     <jsass.version>5.7.3</jsass.version>
 
@@ -122,6 +123,11 @@
         <groupId>com.google.auto.service</groupId>
         <artifactId>auto-service</artifactId>
         <version>${auto-service.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.auto</groupId>
+        <artifactId>auto-common</artifactId>
+        <version>${auto-common.version}</version>
       </dependency>
 
       <!-- Injection -->

--- a/processors/pom.xml
+++ b/processors/pom.xml
@@ -31,6 +31,11 @@
     <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto</groupId>
+      <artifactId>auto-common</artifactId>
     </dependency>
     <dependency>
       <groupId>com.squareup</groupId>
@@ -78,6 +83,90 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <excludes>
+                  <exclude>com.axellience:vue-gwt</exclude>
+                  <exclude>com.google.jsinterop:jsinterop-annotations</exclude>
+                  <exclude>com.google.jsinterop:base</exclude>
+                  <exclude>com.google.elemental2:elemental2-core</exclude>
+                  <exclude>com.google.elemental2:elemental2-dom</exclude>
+                  <exclude>com.google.elemental2:elemental2-promise</exclude>
+                  <exclude>javax.inject:javax.inject</exclude>
+                  <exclude>com.google.j2objc:j2objc-annotations</exclude>
+                  <exclude>com.google.errorprone:error_prone_annotations</exclude>
+                </excludes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.google</pattern>
+                  <shadedPattern>vuegwt.shaded.com.google</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.squareup</pattern>
+                  <shadedPattern>vuegwt.shaded.com.squareup</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.github</pattern>
+                  <shadedPattern>vuegwt.shaded.com.github</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.helger</pattern>
+                  <shadedPattern>vuegwt.shaded.com.helger</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>afu</pattern>
+                  <shadedPattern>vuegwt.shaded.afu</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org</pattern>
+                  <shadedPattern>vuegwt.shaded.org</shadedPattern>
+                </relocation>
+                <!--
+                This is excluded since it causes unsatisfied link errors. Not
+                sure what is going on here, or if it should be shaded at all.
+                -->
+                <!--<relocation>
+                  <pattern>io</pattern>
+                  <shadedPattern>vuegwt.shaded.io</shadedPattern>
+                </relocation>-->
+                <relocation>
+                  <pattern>net</pattern>
+                  <shadedPattern>vuegwt.shaded.net</shadedPattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+              <createSourcesJar>true</createSourcesJar>
+              <filters>
+                <filter>
+                  <artifact>com.google.auto:auto-common</artifact>
+                  <excludes>
+                    <exclude>**/*.java</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>com.google.code.findbugs:jsr305</artifact>
+                  <excludes>
+                    <exclude>**/*.java</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
From https://github.com/google/auto/tree/master/common#processor-resilience

> Auto Common Utilities is used by a variety of annotation processors in Google and new versions may have breaking changes. Users of auto-common are urged to use shade or jarjar (or something similar) in packaging their processors so that conflicting versions of this library do not adversely interact with each other.

This is probably a good idea in general to follow - the config here is an attempt to combine the various dependencies of the processor, so that if another processor in a gwt project happens to use a different version of any of them, there won't be any conflicts.

Note that there are exclusions here, like vue-gwt core, and various jsinterop/elemental2 jars.

There are other benefits here too, like removing .java files from the classpath, so that the j2cl-maven-plugin won't think that those jars also need to be transpiled.

Finally, auto-service was mistakenly added as a scope=compile dependency, when it only is needed at compile time. As a result of this, I discovered that there is an implicit dependency on auto-common, so I added that directly.