### PR TITLE
Small changes to make j2cl and closure happier with this lib

### DIFF
--- a/core/src/main/java/com/axellience/vuegwt/core/client/VueGWT.js
+++ b/core/src/main/java/com/axellience/vuegwt/core/client/VueGWT.js
@@ -1,7 +1,7 @@
 goog.provide("vuegwt");
 
 /** @define {string} */
-goog.define("vuegwt.environment", "production");
+vuegwt.environment = goog.define("vuegwt.environment", "production");
 
 /** @define {string} */
-goog.define("superdevmode", "off");
+var superdevmode = goog.define("superdevmode", "off");

--- a/core/src/main/java/com/axellience/vuegwt/core/client/customelement/VueCustomElement.js
+++ b/core/src/main/java/com/axellience/vuegwt/core/client/customelement/VueCustomElement.js
@@ -1,0 +1,21 @@
+/**
+ * @externs
+ */
+var VueCustomElement = {};
+/**
+ *
+ * @param {Object} param
+ * @return {Element}
+ */
+VueCustomElement.createElement = function(param) {};
+
+/**
+ * @type {Object}
+ */
+Element.prototype.__vue_custom_element__;
+
+/**
+ * @param {Object} param
+ * @return {Function}
+ */
+Function.prototype.extend = function(param) {};

--- a/core/src/main/java/com/axellience/vuegwt/core/client/customelement/VueCustomElementType.java
+++ b/core/src/main/java/com/axellience/vuegwt/core/client/customelement/VueCustomElementType.java
@@ -10,10 +10,13 @@ public class VueCustomElementType<T extends IsVueComponent> {
 
   @JsOverlay
   public final VueCustomElement<T> create() {
-    return createElement(this);
+    return VCE.createElement(this);
   }
 
-  @JsMethod(namespace = "VueCustomElement")
-  private native static <T extends IsVueComponent> VueCustomElement<T> createElement(
-      VueCustomElementType<T> type);
+  @JsType(isNative = true, namespace = "<global>", name = "VueCustomElement")
+  private static final class VCE {
+    @JsMethod
+    private native static <T extends IsVueComponent> VueCustomElement<T> createElement(
+            VueCustomElementType<T> type);
+  }
 }


### PR DESCRIPTION
First, introduces a JS file for `@externs`, so that closure-compiler knows about the types and fields we insist will be present at runtime. If we had a real type for the constructor (instead of just Function), we would make a specific type for that instead. Without VCE, j2cl is believing that there is an actual module (closure, ecmascript, etc) names VueCustomElement instead of just a js.dot.separated.object. In theory we could change the name to something like name="VueCustomElement.createElement" instead, and mark the namespace as global, but it turns out _that_ doesnt work in GWT2, so this hopefully serves as a consistent way to do it for everyone.

Finally, closure has changed its rules about invoking goog.define, the changes made here make it happy with our code. Chances are excellent we'll need to revisit `superdevmode` later and put it somewhere shared, but for now this at least compiles correctly.