### PR TITLE
feature: boolean props

### DIFF
--- a/core/src/main/java/com/axellience/vuegwt/core/annotations/component/Prop.java
+++ b/core/src/main/java/com/axellience/vuegwt/core/annotations/component/Prop.java
@@ -25,7 +25,7 @@ public @interface Prop {
   /**
    * Should check the type of the property. By default check based on the Java type.
    *
-   * @return true if we should check the type, false otherwise. Default to false.
+   * @return true if we should check the type, false otherwise. Default to true.
    */
-  boolean checkType() default false;
+  boolean checkType() default true;
 }

--- a/processors/src/test/resources/props/compileresult/PropComponentExposedType.java
+++ b/processors/src/test/resources/props/compileresult/PropComponentExposedType.java
@@ -18,7 +18,7 @@ public class PropComponentExposedType extends PropComponent {
     VueComponentOptions<PropComponent> options = new VueComponentOptions<PropComponent>();
     Proto p = __proto__;
     options.setComponentExportedTypePrototype(p);
-    options.addJavaProp("myProp", VueGWTTools.getFieldName(this, () -> this.myProp = 1), false, null);
+    options.addJavaProp("myProp", VueGWTTools.getFieldName(this, () -> this.myProp = 1), false, "Number");
     options.addHookMethod("created", p.vg$created);
     options.initData(true, VueGWTTools.getFieldsName(this, () -> {
     }));

--- a/tests/tests-app/src/main/java/com/axellience/vuegwt/testsapp/client/components/basic/prop/PropParentTestComponent.html
+++ b/tests/tests-app/src/main/java/com/axellience/vuegwt/testsapp/client/components/basic/prop/PropParentTestComponent.html
@@ -1,5 +1,6 @@
 <div>
   <prop-test :optional-prop='optionalPropParent'
              :required-prop='requiredPropParent'
-             :non-observed-prop='getNonObservedObject()'/>
+             :non-observed-prop='getNonObservedObject()'
+             boolean-prop-true/>
 </div>

--- a/tests/tests-app/src/main/java/com/axellience/vuegwt/testsapp/client/components/basic/prop/PropTestComponent.html
+++ b/tests/tests-app/src/main/java/com/axellience/vuegwt/testsapp/client/components/basic/prop/PropTestComponent.html
@@ -1,4 +1,6 @@
 <ul>
   <li id='optional-prop'>{{ optionalProp }}</li>
   <li id='required-prop'>{{ requiredProp }}</li>
+  <li id='boolean-prop-true'>{{ booleanPropTrue }}</li>
+  <li id='boolean-prop-false'>{{ booleanPropFalse }}</li>
 </ul>

--- a/tests/tests-app/src/main/java/com/axellience/vuegwt/testsapp/client/components/basic/prop/PropTestComponent.java
+++ b/tests/tests-app/src/main/java/com/axellience/vuegwt/testsapp/client/components/basic/prop/PropTestComponent.java
@@ -16,4 +16,10 @@ public class PropTestComponent implements IsVueComponent {
 
   @Prop
   SimpleObject nonObservedProp;
+
+  @Prop
+  boolean booleanPropTrue;
+
+  @Prop
+  boolean booleanPropFalse;
 }

--- a/tests/tests-runner/src/test/javascript/components/basic/prop.spec.js
+++ b/tests/tests-runner/src/test/javascript/components/basic/prop.spec.js
@@ -46,4 +46,16 @@ describe('@Prop', () => {
   it('should not be observed if original value wasn\'t', () => {
     expect(component.getNonObservedObject().__ob__).to.be.undefined;
   });
+
+  it('should pass boolean props to true when defined', async () => {
+    const booleanPropTrue = getElement(component,
+        '#boolean-prop-true').innerText;
+    expect(booleanPropTrue).to.equal('true');
+  });
+
+  it('should pass boolean props to false when not defined', async () => {
+    const booleanPropFalse = getElement(component,
+        '#boolean-prop-false').innerText;
+    expect(booleanPropFalse).to.equal('false');
+  });
 });


### PR DESCRIPTION
Add support for boolean props binding: https://vuejs.org/v2/guide/components-props.html#Passing-a-Boolean

This also changes the `checkType` default to `true`. This means that Vue GWT will pass the inferred type of all properties to Vue.
Vue uses this type for example in the case of boolean props binding. If the type passed is `Boolean` and an attribute with the name of the prop is passed to the component then Vue will set the prop value to `true`.