### PR TITLE
GWT 2.9.0

### DIFF
--- a/core/src/main/java/com/axellience/vuegwt/core/client/directive/options/VueDirectiveOptions.java
+++ b/core/src/main/java/com/axellience/vuegwt/core/client/directive/options/VueDirectiveOptions.java
@@ -68,7 +68,7 @@ public abstract class VueDirectiveOptions implements JsPropertyMap {
     JsString jsString = cast(jsFunction.toString());
 
     // Get content between first { and last }
-    JsString m = cast(jsString.match(new JsRegExp("\\{([\\s\\S]*)\\}", "m"))[1]);
+    JsString m = cast(jsString.match(new JsRegExp("\\{([\\s\\S]*)\\}", "m")).getAt(1));
     // Strip comments
     return m.replace(new JsRegExp("^\\s*\\/\\/.*$", "mg"), "").trim();
   }

--- a/core/src/main/java/com/axellience/vuegwt/core/client/tools/JsUtils.java
+++ b/core/src/main/java/com/axellience/vuegwt/core/client/tools/JsUtils.java
@@ -33,7 +33,7 @@ public class JsUtils {
   }
 
   public static <T> JsArray<T> arrayFrom(Collection<T> collection) {
-    return new JsArray<>(collection.toArray());
+    return new JsArray(collection.toArray());
   }
 
   public static <K, V> JsArray<V> arrayFrom(Map<K, V> map) {

--- a/core/src/main/java/com/axellience/vuegwt/core/client/tools/VueGWTTools.java
+++ b/core/src/main/java/com/axellience/vuegwt/core/client/tools/VueGWTTools.java
@@ -248,6 +248,6 @@ public class VueGWTTools {
         new Function("this[\"" + sourceKey + "\"][\"" + sourceProperty + "\"] = arguments[0];"));
     PROXY_SHARED_DEFINITION.set("get",
         new Function("return this[\"" + sourceKey + "\"][\"" + sourceProperty + "\"];"));
-    JsObject.defineProperty(target, targetProperty, PROXY_SHARED_DEFINITION);
+    JsObject.defineProperty(target, targetProperty, Js.uncheckedCast(PROXY_SHARED_DEFINITION));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -50,13 +50,13 @@
 
   <properties>
     <!-- Plugins -->
-    <plugin.version.gwt.maven>1.0-rc-9</plugin.version.gwt.maven>
+    <plugin.version.gwt.maven>1.0.0</plugin.version.gwt.maven>
 
     <!-- Dependencies -->
-    <gwt.version>2.8.2</gwt.version>
+    <gwt.version>2.9.0</gwt.version>
     <jsinterop.version>1.0.2</jsinterop.version>
-    <jsinterop-base.version>1.0.0-RC1</jsinterop-base.version>
-    <elemental.version>1.0.0-RC1</elemental.version>
+    <jsinterop-base.version>1.0.0</jsinterop-base.version>
+    <elemental.version>1.1.0</elemental.version>
 
     <javapoet.version>1.12.1</javapoet.version>
     <jericho.version>3.4</jericho.version>
@@ -70,7 +70,7 @@
     <junit.version>5.1.0</junit.version>
     <junit-platform.version>1.1.0</junit-platform.version>
     <opentest4j.version>1.0.0</opentest4j.version>
-    <testing-compile.version>0.18</testing-compile.version>
+    <testing-compile.version>0.19</testing-compile.version>
     <maven.surefire.plugin.version>2.19</maven.surefire.plugin.version>
 
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/processors/pom.xml
+++ b/processors/pom.xml
@@ -84,6 +84,12 @@
       <artifactId>opentest4j</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.gwt</groupId>
+      <artifactId>gwt-user</artifactId>
+      <version>2.9.0</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/processors/src/main/java/com/axellience/vuegwt/processors/component/template/parser/variable/DestructuredPropertyInfo.java
+++ b/processors/src/main/java/com/axellience/vuegwt/processors/component/template/parser/variable/DestructuredPropertyInfo.java
@@ -23,7 +23,7 @@ public class DestructuredPropertyInfo extends VariableInfo {
       String typeName = getType().toString();
       String anyGetterName =
           "as" + typeName.substring(0, 1).toUpperCase() + typeName.substring(1) + "()";
-      return destructuredVariable.getName() + ".getAny(\"" + getName() + "\")." + anyGetterName;
+      return destructuredVariable.getName() + ".getAsAny(\"" + getName() + "\")." + anyGetterName;
     }
 
     return "((" + getType() + ") " + destructuredVariable.getName() + ".get(\""

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -16,7 +16,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Plugins -->
-    <plugin.version.gwt.maven>1.0-rc-9</plugin.version.gwt.maven>
+    <plugin.version.gwt.maven>1.0.0</plugin.version.gwt.maven>
   </properties>
 
   <modules>

--- a/tests/tests-app-wrapper-gwt2/pom.xml
+++ b/tests/tests-app-wrapper-gwt2/pom.xml
@@ -16,7 +16,7 @@
   <packaging>gwt-app</packaging>
 
   <properties>
-    <gwt.version>2.8.2</gwt.version>
+    <gwt.version>2.9.0</gwt.version>
 
     <auto-service.version>1.0-rc4</auto-service.version>
 

--- a/tests/tests-app-wrapper-j2cl/pom.xml
+++ b/tests/tests-app-wrapper-j2cl/pom.xml
@@ -16,7 +16,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <gwt.version>2.8.2</gwt.version>
+    <gwt.version>2.9.0</gwt.version>
 
     <frontend-maven-plugin.version>1.8.0</frontend-maven-plugin.version>
     <node.version>v10.16.0</node.version>

--- a/tests/tests-app/src/main/java/com/axellience/vuegwt/testsapp/client/VueGwtTestsApp.java
+++ b/tests/tests-app/src/main/java/com/axellience/vuegwt/testsapp/client/VueGwtTestsApp.java
@@ -69,6 +69,7 @@ import com.axellience.vuegwt.testsapp.client.components.vmodel.VModelComponent;
 import com.axellience.vuegwt.testsapp.client.components.vmodel.VModelComponentFactory;
 import elemental2.core.Function;
 import elemental2.core.JsArray;
+import elemental2.core.JsArray.ForEachCallbackFn;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 import jsinterop.base.JsPropertyMap;
@@ -140,7 +141,12 @@ public class VueGwtTestsApp {
     registerTestComponent(ComputedOverrideComponent.class, ComputedOverrideComponentFactory.get());
     registerTestComponent(RefParentTestComponent.class, RefParentTestComponentFactory.get());
 
-    Window.onVueGwtTestsReady.forEach((f, i, a) -> f.call(i, a));
+    Window.onVueGwtTestsReady.forEach(new ForEachCallbackFn<Function>() {
+      @Override
+      public Object onInvoke(Function f, int i, JsArray<Function> a) {
+        return f.call(i, a);
+      }
+    });
   }
 
   private static <T extends IsVueComponent> void registerTestComponent(Class<T> componentClass,

--- a/tests/tests-app/src/main/java/com/axellience/vuegwt/testsapp/client/components/slots/SlotScopeParentComponent.html
+++ b/tests/tests-app/src/main/java/com/axellience/vuegwt/testsapp/client/components/slots/SlotScopeParentComponent.html
@@ -2,9 +2,9 @@
 
 <slot-scope-child ref="child">
   <template v-slot="scope">
-    <div id="myInt">{{ scope.getAny("myInt").asInt() + 5 }}</div>
-    <div id="myIntCamelCase">{{ scope.getAny("myIntCamelCase").asInt() + 5 }}</div>
-    <div id="myIntLiteral">{{ scope.getAny("myIntLiteral").asInt() + 10 }}</div>
+    <div id="myInt">{{ scope.getAsAny("myInt").asInt() + 5 }}</div>
+    <div id="myIntCamelCase">{{ scope.getAsAny("myIntCamelCase").asInt() + 5 }}</div>
+    <div id="myIntLiteral">{{ scope.getAsAny("myIntLiteral").asInt() + 10 }}</div>
     <div id="myInteger">{{ ((Integer) scope.get("myInteger")) + 5 }}</div>
     <div id="myString">{{ ((String) scope.get("myString")) + "_HELLO" }}</div>
     <div id="myStringLiteral">{{ ((String) scope.get("myStringLiteral")) + "_HELLO" }}</div>

--- a/tests/tests-app/src/main/java/com/axellience/vuegwt/testsapp/client/components/slots/SlotScopeParentOldComponent.html
+++ b/tests/tests-app/src/main/java/com/axellience/vuegwt/testsapp/client/components/slots/SlotScopeParentOldComponent.html
@@ -2,9 +2,9 @@
 
 <slot-scope-child ref="child">
   <template slot-scope="scope">
-    <div id="myInt">{{ scope.getAny("myInt").asInt() + 5 }}</div>
-    <div id="myIntCamelCase">{{ scope.getAny("myIntCamelCase").asInt() + 5 }}</div>
-    <div id="myIntLiteral">{{ scope.getAny("myIntLiteral").asInt() + 10 }}</div>
+    <div id="myInt">{{ scope.getAsAny("myInt").asInt() + 5 }}</div>
+    <div id="myIntCamelCase">{{ scope.getAsAny("myIntCamelCase").asInt() + 5 }}</div>
+    <div id="myIntLiteral">{{ scope.getAsAny("myIntLiteral").asInt() + 10 }}</div>
     <div id="myInteger">{{ ((Integer) scope.get("myInteger")) + 5 }}</div>
     <div id="myString">{{ ((String) scope.get("myString")) + "_HELLO" }}</div>
     <div id="myStringLiteral">{{ ((String) scope.get("myStringLiteral")) + "_HELLO" }}</div>

--- a/tests/tests-app/src/main/module.gwt.xml
+++ b/tests/tests-app/src/main/module.gwt.xml
@@ -1,0 +1,9 @@
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.8.0//EN"
+  "http://www.gwtproject.org/doctype/2.8.0/gwt-module.dtd">
+<module>
+  <inherits name="jsinterop.base.Base"/>
+  <inherits name="elemental2.core.Core"/>
+  <inherits name="elemental2.dom.Dom"/>
+  <inherits name="javax.inject.Inject"/>
+  <source path="client"/>
+</module>


### PR DESCRIPTION
The following libraries has been updated:
- GWT from 2.8.2 to 2.9.0
- JsInterop from 1.0.0-RC1 to 1.0.0
- Elemental from 1.1.0-RC1 to 1.1.0
- GWT Maven Plugin from 1.0-rc-9 to 1.0.0